### PR TITLE
handle duplicate community names

### DIFF
--- a/.env_insert_missing_name_dups
+++ b/.env_insert_missing_name_dups
@@ -1,0 +1,6 @@
+host=192.168.178.181
+dbname=sormas_db
+port=5432
+username=postgres
+password=postgres
+input=/srv

--- a/Dockerfile-Insert-Missing-Name-Dups
+++ b/Dockerfile-Insert-Missing-Name-Dups
@@ -1,0 +1,14 @@
+###
+# USAGE: docker build -f Dockerfile-Infra-Cleaner -t infra-cleaner .
+# RUN: docker run -it --network host --env-file .env_infra_cleaner  -v "$(pwd)/out:/srv" infra-cleaner
+FROM alpine:3.15
+
+RUN apk update --no-cache && \
+    apk upgrade --no-cache && \
+    apk add --no-cache --upgrade postgresql14 py3-pip
+
+COPY requirements.txt /root
+RUN pip3 install -r /root/requirements.txt
+COPY src/insert_missing_dup_names/insert_missing_name_dups.py /root
+WORKDIR /root/
+CMD [ "python3", "/root/insert_missing_name_dups.py" ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,11 @@ node {
     	echo 'Building central-verifier'
     	sh """
     	sudo buildah bud --pull-always --no-cache -f Dockerfile-Central-Verifier -t central-verifier:${VERSION} .
-    	"""        
+    	"""
+    	echo 'Building insert-missing-name-dups'
+    	sh """
+    	sudo buildah bud --pull-always --no-cache -f Dockerfile-Insert-Missing-Name-Dups -t insert-missing-name-dups:${VERSION} .
+    	"""  		
     }
       
     stage('Push image into registry') {
@@ -31,16 +35,20 @@ node {
         	sh """
         	sudo buildah login -u '$MY_SECRET_USER_NLI' -p '$MY_SECRET_USER_PASSWORD_NLI' registry.netzlink.com
         	sudo buildah push -f v2s2 central-aligner:${VERSION} registry.netzlink.com/hzibraunschweig/central-aligner:${VERSION}
-            	sudo buildah push -f v2s2 central-aligner:${VERSION} registry.netzlink.com/hzibraunschweig/central-aligner:latest
-		sudo buildah push -f v2s2 central-aligner:${VERSION} registry.netzlink.com/hzibraunschweig/central-aligner:stable
+            sudo buildah push -f v2s2 central-aligner:${VERSION} registry.netzlink.com/hzibraunschweig/central-aligner:latest
+			sudo buildah push -f v2s2 central-aligner:${VERSION} registry.netzlink.com/hzibraunschweig/central-aligner:stable
 
         	sudo buildah push -f v2s2 infra-cleaner:${VERSION} registry.netzlink.com/hzibraunschweig/infra-cleaner:${VERSION}
-            	sudo buildah push -f v2s2 infra-cleaner:${VERSION} registry.netzlink.com/hzibraunschweig/infra-cleaner:latest
-		sudo buildah push -f v2s2 infra-cleaner:${VERSION} registry.netzlink.com/hzibraunschweig/infra-cleaner:stable
+            sudo buildah push -f v2s2 infra-cleaner:${VERSION} registry.netzlink.com/hzibraunschweig/infra-cleaner:latest
+			sudo buildah push -f v2s2 infra-cleaner:${VERSION} registry.netzlink.com/hzibraunschweig/infra-cleaner:stable
 
         	sudo buildah push -f v2s2 central-verifier:${VERSION} registry.netzlink.com/hzibraunschweig/central-verifier:${VERSION}
-            	sudo buildah push -f v2s2 central-verifier:${VERSION} registry.netzlink.com/hzibraunschweig/central-verifier:latest
-		sudo buildah push -f v2s2 central-verifier:${VERSION} registry.netzlink.com/hzibraunschweig/central-verifier:stable
+            sudo buildah push -f v2s2 central-verifier:${VERSION} registry.netzlink.com/hzibraunschweig/central-verifier:latest
+			sudo buildah push -f v2s2 central-verifier:${VERSION} registry.netzlink.com/hzibraunschweig/central-verifier:stable
+
+        	sudo buildah push -f v2s2 insert-missing-name-dups:${VERSION} registry.netzlink.com/hzibraunschweig/insert-missing-name-dups:${VERSION}
+            sudo buildah push -f v2s2 insert-missing-name-dups:${VERSION} registry.netzlink.com/hzibraunschweig/insert-missing-name-dups:latest
+			sudo buildah push -f v2s2 insert-missing-name-dups:${VERSION} registry.netzlink.com/hzibraunschweig/insert-missing-name-dups:stable			
         	"""
         }    
 	}

--- a/src/insert_missing_dup_names/insert_missing_name_dups.py
+++ b/src/insert_missing_dup_names/insert_missing_name_dups.py
@@ -1,0 +1,111 @@
+import os
+
+from collections import defaultdict
+from datetime import datetime
+
+import psycopg
+import json
+import argparse
+
+import logging
+
+from psycopg.rows import dict_row
+
+error_list = []
+
+FORMAT = '%(message)s'
+
+logFormatter = logging.Formatter(FORMAT)
+rootLogger = logging.getLogger()
+
+fileHandler = logging.FileHandler("output.log")
+fileHandler.setFormatter(logFormatter)
+rootLogger.addHandler(fileHandler)
+
+consoleHandler = logging.StreamHandler()
+consoleHandler.setFormatter(logFormatter)
+rootLogger.addHandler(consoleHandler)
+rootLogger.setLevel(logging.DEBUG)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-H", "--host", default=os.environ.get("host"), help="database server host or socket directory",
+                    action="store")
+parser.add_argument("-P", "--port", default=os.environ.get("PORT"), help="port to connect to", action="store")
+parser.add_argument("-d", "--dbname", default=os.environ.get("dbname"), help="database name to connect to)",
+                    action="store")
+parser.add_argument("-u", "--username", default=os.environ.get("username"),
+                    help="database user name",
+                    action="store")
+parser.add_argument("-p", "--password", default=os.environ.get("password"), help="password for user", action="store")
+parser.add_argument("-i", "--input", default=os.environ.get("input"), help="path where to expect the central data",
+                    action="store")
+
+args, unknown = parser.parse_known_args()
+
+assert len(unknown) == 0
+
+CONNECTION = f"host={args.host} dbname={args.dbname} user={args.username} password={args.password} port={args.port}"
+logging.info(f'Connecting to {args.host}')
+PATH = args.input
+
+NUMBER_OF_NAMES: dict[str, int] = {}
+
+
+def insert_missing(group):
+    with psycopg.connect(CONNECTION) as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            present_communities = cur.execute("SELECT * FROM community WHERE name = %s", (group[0],)).fetchall()
+
+            for present_community in present_communities:
+                district_id = present_community['district_id']
+                # fetch district
+                district = cur.execute("SELECT uuid,name FROM district WHERE id = %s", (district_id,)).fetchone()
+                assert district is not None
+                # find the community in the group that has the same district
+                community = next(filter(lambda x: x['district']['uuid'] == district['uuid'], group[1]), None)
+                assert community is not None
+                # update the uuid of the present community
+                cur.execute("UPDATE community SET uuid = %s WHERE id = %s",
+                            (community['uuid'], present_community['id']))
+                logging.info(f"Updated community {present_community} in district {district['name']} to uuid {community['uuid']}")
+
+            # insert the remaining communities
+            for community in group[1]:
+                count = cur.execute("SELECT COUNT(*) FROM community WHERE uuid = %s", (community['uuid'],)).fetchone()[
+                    'count']
+                if count == 0:
+                    max_id = cur.execute(f"SELECT max(id) FROM community").fetchone()['max']
+
+                    name: str = community['name']
+                    external_id: str = community['externalID']
+                    # force download again
+                    date = datetime.fromisoformat('2000-01-01').strftime("%Y-%m-%d %H:%M:%S")
+                    district_id = \
+                    cur.execute("SELECT id FROM district WHERE uuid = %s", (community['district']['uuid'],)).fetchone()[
+                        'id']
+                    assert district_id is not None
+
+                    cur.execute(f"""
+                    insert into community 
+                    (id, changedate, creationdate, name, uuid, district_id, archived, externalid,  centrally_managed, sys_period) 
+                    values ('{max_id + 1}','{date}', '{date}', %s, '{community['uuid']}', {district_id}, false, {external_id},true, '["{date}",)');
+                    """, (name,))
+                    logging.info(f"Inserted central value: {community}")
+
+
+def main():
+    community_path = f'{PATH}/germany/community.json'
+    with open(community_path) as f:
+        community_values = map(lambda x: x['value'], json.load(f))
+        # group community values by name
+        grouped_by_name = defaultdict(list)
+        for community in community_values:
+            grouped_by_name[community['name']].append(community)
+
+        groups = list(filter(lambda x: len(x[1]) > 1, grouped_by_name.items()))
+        for group in groups:
+            insert_missing(group)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
@nliakm This needs to go into a new tool container
```text
usage: insert_missing_name_dups.py [-h] [-H HOST] [-P PORT] [-d DBNAME]
                                   [-u USERNAME] [-p PASSWORD] [-i INPUT]

options:
  -h, --help            show this help message and exit
  -H HOST, --host HOST  database server host or socket directory
  -P PORT, --port PORT  port to connect to
  -d DBNAME, --dbname DBNAME
                        database name to connect to)
  -u USERNAME, --username USERNAME
                        database user name
  -p PASSWORD, --password PASSWORD
                        password for user
  -i INPUT, --input INPUT
                        path where to expect the central data
```
Please add this to your internal documentation