### PR TITLE
[#26] move New Caledonia to Western Europe

### DIFF
--- a/import/csv/germany/sormas_gemeinden_master.csv
+++ b/import/csv/germany/sormas_gemeinden_master.csv
@@ -6428,7 +6428,7 @@ Antdorf;0;Bayern;LK Weilheim-Schongau;0;09190113
 Altenstadt;0;Bayern;LK Weilheim-Schongau;0;09190111
 Waginger See;0;Bayern;LK Traunstein;0;09189452
 Chiemsee (See);0;Bayern;LK Traunstein;0;09189451
-Traunstein, Gm.fr. Geb.;Bayern;LK Traunstein;0;09189444
+Traunstein, Gm.fr. Geb.;0;Bayern;LK Traunstein;0;09189444
 Wonneberg;0;Bayern;LK Traunstein;0;09189165
 Waging a.See, M;0;Bayern;LK Traunstein;0;09189162
 Vachendorf;0;Bayern;LK Traunstein;0;09189161

--- a/import/csv/germany/sormas_laender_survnet.csv
+++ b/import/csv/germany/sormas_laender_survnet.csv
@@ -124,7 +124,7 @@ NAM;Namibia;Southern Africa;21000311;516
 NRU;Nauru;Oceania;21000507;520
 NPL;Nepal;Southern Asia;21000215;524
 NLD;Niederlande;Western Europe;21000135;528
-NCL;Neukaledonien;Oceania;21000518;540
+NCL;Neukaledonien;Western Europe;21000518;540
 VUT;Vanuatu;Oceania;21000514;548
 NZL;Neuseeland;Oceania;21000502;554
 NIC;Nicaragua;Central America;21000412;558

--- a/out/germany/country.csv
+++ b/out/germany/country.csv
@@ -124,7 +124,7 @@ NAM,Namibia,Southern Africa,21000311,516,66c31974-9028-5ff4-adf6-cab71e1eb08f
 NRU,Nauru,Oceania,21000507,520,30761a8d-ae8e-539f-b462-22ed21bdaa26
 NPL,Nepal,Southern Asia,21000215,524,89e5e11b-d4c2-5a6e-97d5-438d8cd5f185
 NLD,Niederlande,Western Europe,21000135,528,79ba8f52-215e-54fb-91a0-2083b7942c2a
-NCL,Neukaledonien,Oceania,21000518,540,75edef4b-a7ab-57e3-9efe-fe5ea4724da7
+NCL,Neukaledonien,Western Europe,21000518,540,75edef4b-a7ab-57e3-9efe-fe5ea4724da7
 VUT,Vanuatu,Oceania,21000514,548,2b638f81-494b-5da5-8c69-2b731d5903fc
 NZL,Neuseeland,Oceania,21000502,554,4f74a7e6-06f6-50d5-9693-7d9a020c0ced
 NIC,Nicaragua,Central America,21000412,558,9fe8e270-54e1-5fc9-a7d5-b134bee94c81

--- a/out/germany/country.json
+++ b/out/germany/country.json
@@ -1758,9 +1758,9 @@
       "unoCode": "540",
       "uuid": "75edef4b-a7ab-57e3-9efe-fe5ea4724da7",
       "subcontinent": {
-        "uuid": "e4dbc268-f7ef-5159-b392-7f4e7dca0f7e"
+        "uuid": "ad6da763-1194-5419-be74-f3379d3fd4b3"
       },
-      "changeDate": "2022-05-20T09:36:31.200728"
+      "changeDate": "2023-02-28T11:51:01.519954"
     }
   },
   {


### PR DESCRIPTION
fixes #26 

Traunstein was missing a field, I decided to include it here. Probably deleted it in the past by accident.

Besides this, I manually adjusted the entries. `ad6da763-1194-5419-be74-f3379d3fd4b3` is the uuid of Western Europe subcontinent.